### PR TITLE
Desolestice/fix plethora swing

### DIFF
--- a/src/main/java/io/sc3/plethora/gameplay/registry/Registration.java
+++ b/src/main/java/io/sc3/plethora/gameplay/registry/Registration.java
@@ -23,6 +23,7 @@ import io.sc3.plethora.gameplay.modules.introspection.IntrospectionModuleItem;
 import io.sc3.plethora.gameplay.modules.keyboard.KeyboardKeyPacket;
 import io.sc3.plethora.gameplay.modules.keyboard.KeyboardModuleItem;
 import io.sc3.plethora.gameplay.modules.keyboard.ServerKeyListener;
+import io.sc3.plethora.gameplay.modules.kinetic.KineticMethods;
 import io.sc3.plethora.gameplay.modules.kinetic.KineticModuleItem;
 import io.sc3.plethora.gameplay.modules.kinetic.KineticTurtleUpgrade;
 import io.sc3.plethora.gameplay.modules.laser.LaserEntity;
@@ -39,6 +40,7 @@ import io.sc3.plethora.gameplay.redstone.RedstoneIntegratorTicker;
 import io.sc3.plethora.integration.InternalIntegration;
 import io.sc3.plethora.integration.computercraft.registry.ComputerCraftMetaRegistration;
 import io.sc3.plethora.integration.computercraft.registry.ComputerCraftMethodRegistration;
+import io.sc3.plethora.integration.vanilla.method.EntityKineticMethods;
 import io.sc3.plethora.integration.vanilla.registry.VanillaConverterRegistration;
 import io.sc3.plethora.integration.vanilla.registry.VanillaMetaRegistration;
 import io.sc3.plethora.integration.vanilla.registry.VanillaMethodRegistration;
@@ -155,6 +157,7 @@ public final class Registration {
     CanvasHandler.registerServerEvents();
     ServerKeyListener.registerEvents();
     LaserEntity.initLaserTracker();
+    EntityKineticMethods.initKineticDigTracker();
 
     RecipeHandlers.registerSerializers();
   }

--- a/src/main/java/io/sc3/plethora/integration/vanilla/method/EntityKineticMethods.kt
+++ b/src/main/java/io/sc3/plethora/integration/vanilla/method/EntityKineticMethods.kt
@@ -110,9 +110,8 @@ object EntityKineticMethods {
             val result = fakePlayer.dig(hit.blockPos, hit.side)
             FutureMethodResult.result(result.left, result.right)
           } else {
-            startDigging(player, hit)
-
             if(player.world.canPlayerModifyAt(player, baseHit.blockPos)){
+              startDigging(player, hit)
               FutureMethodResult.result(true, "Block")
             }else {
               FutureMethodResult.result(false, "No permission to break here")

--- a/src/main/java/io/sc3/plethora/integration/vanilla/method/EntityKineticMethods.kt
+++ b/src/main/java/io/sc3/plethora/integration/vanilla/method/EntityKineticMethods.kt
@@ -122,11 +122,11 @@ object EntityKineticMethods {
     }
   }
 
-  val SWINGING = SubtargetedModuleMethod.of(
-    "swinging", KINETIC_M, LivingEntity::class.java,
+  val IS_SWINGING = SubtargetedModuleMethod.of(
+    "isSwinging", KINETIC_M, LivingEntity::class.java,
     "function():boolean -- Returns true if the player is currently swinging their main hand."
-  ) { unbaked, _ -> swinging(unbaked) }
-  private fun swinging(unbaked: IUnbakedContext<IModuleContainer>): FutureMethodResult {
+  ) { unbaked, _ -> isSwinging(unbaked) }
+  private fun isSwinging(unbaked: IUnbakedContext<IModuleContainer>): FutureMethodResult {
     val ctx = KineticMethods.getContext(unbaked)
     val playerCtx = KineticMethods.getPlayer(ctx)
     val player = playerCtx.player

--- a/src/main/java/io/sc3/plethora/integration/vanilla/method/EntityKineticMethods.kt
+++ b/src/main/java/io/sc3/plethora/integration/vanilla/method/EntityKineticMethods.kt
@@ -9,19 +9,33 @@ import io.sc3.plethora.api.module.SubtargetedModuleMethod
 import io.sc3.plethora.gameplay.modules.kinetic.KineticMethods
 import io.sc3.plethora.gameplay.registry.PlethoraModules.KINETIC_M
 import io.sc3.plethora.integration.PlayerInteractionHelpers
+import io.sc3.plethora.mixin.ServerPlayerInteractionManagerAccessor
+import io.sc3.plethora.mixin.ServerPlayerInteractionManagerInvoker
 import io.sc3.plethora.util.Helpers.normaliseAngle
 import io.sc3.plethora.util.PlayerHelpers
+import net.fabricmc.fabric.api.event.lifecycle.v1.ServerTickEvents
+import net.minecraft.block.Blocks
+import net.minecraft.block.FluidBlock
+import net.minecraft.client.MinecraftClient
 import net.minecraft.entity.LivingEntity
+import net.minecraft.network.packet.c2s.play.PlayerActionC2SPacket
+import net.minecraft.network.packet.s2c.play.BlockBreakingProgressS2CPacket
 import net.minecraft.network.packet.s2c.play.PositionFlag
+import net.minecraft.server.MinecraftServer
 import net.minecraft.server.network.ServerPlayerEntity
+import net.minecraft.text.Text
+import net.minecraft.util.Hand
 import net.minecraft.util.hit.BlockHitResult
 import net.minecraft.util.hit.EntityHitResult
 import net.minecraft.util.hit.HitResult
+import net.minecraft.util.math.BlockPos
 import net.minecraft.util.math.MathHelper
+import net.minecraft.world.World
 import java.util.*
 
 object EntityKineticMethods {
   private val LOOK_FLAGS = EnumSet.of(PositionFlag.X, PositionFlag.Y, PositionFlag.Z)
+  private val trackedDigEvents = mutableMapOf<ServerPlayerEntity, BlockPos>()
 
   val LOOK = SubtargetedModuleMethod.of(
     "look", KINETIC_M, LivingEntity::class.java,
@@ -94,14 +108,119 @@ object EntityKineticMethods {
             val result = fakePlayer.dig(hit.blockPos, hit.side)
             FutureMethodResult.result(result.left, result.right)
           } else {
-            FutureMethodResult.result(false, "Nothing to do here")
+            startDigging(player, hit)
+            FutureMethodResult.result(true, "Block")
           }
         }
-        else -> FutureMethodResult.result(false, "Nothing to do here")
+        else -> {
+          FutureMethodResult.result(false, "Nothing to do here")
+        }
       }
     } finally {
       player.clearActiveItem()
       fakePlayer?.updateCooldown()
     }
+  }
+
+  val SWINGING = SubtargetedModuleMethod.of(
+    "swinging", KINETIC_M, LivingEntity::class.java,
+    "function():boolean -- Returns true if the player is currently swinging their main hand."
+  ) { unbaked, _ -> swinging(unbaked) }
+  private fun swinging(unbaked: IUnbakedContext<IModuleContainer>): FutureMethodResult {
+    val ctx = KineticMethods.getContext(unbaked)
+    val playerCtx = KineticMethods.getPlayer(ctx)
+    val player = playerCtx.player
+
+    return FutureMethodResult.result(trackedDigEvents.containsKey(player))
+  }
+
+  private fun startDigging(player: ServerPlayerEntity, baseHit: BlockHitResult) {
+    if(trackedDigEvents.containsKey(player)){
+      stopDigging(player)
+    }
+
+    player.interactionManager.processBlockBreakingAction(
+      baseHit.blockPos,
+      PlayerActionC2SPacket.Action.START_DESTROY_BLOCK,
+      baseHit.side,
+      player.world.topY,
+      0
+    )
+
+    trackedDigEvents[player] = baseHit.blockPos
+  }
+
+  private fun stopDigging(player: ServerPlayerEntity) {
+    if(trackedDigEvents.containsKey(player)){
+      setBlockBreakingInfo(player.server, player.world, player.id, trackedDigEvents[player]!!, -1)
+      trackedDigEvents.remove(player)
+    }
+  }
+
+  private fun setBlockBreakingInfo(server: MinecraftServer, world: World, entityId: Int, pos: BlockPos, progress: Int) {
+    val var4: Iterator<*> = server.playerManager.playerList.iterator()
+    while (var4.hasNext()) {
+      val serverPlayerEntity = var4.next() as ServerPlayerEntity?
+      if (serverPlayerEntity != null && serverPlayerEntity.world === world) {
+        val d = pos.x.toDouble() - serverPlayerEntity.x
+        val e = pos.y.toDouble() - serverPlayerEntity.y
+        val f = pos.z.toDouble() - serverPlayerEntity.z
+        if (d * d + e * e + f * f < 1024.0) {
+          serverPlayerEntity.networkHandler.sendPacket(BlockBreakingProgressS2CPacket(entityId, pos, progress))
+        }
+      }
+    }
+  }
+
+  @JvmStatic
+  fun initKineticDigTracker(){
+    ServerTickEvents.END_SERVER_TICK.register(ServerTickEvents.EndTick { server ->
+      for (event in trackedDigEvents) {
+        val player = event.key
+        val pos = event.value
+
+        if(player.isDisconnected){
+          trackedDigEvents.remove(player)
+          continue
+        }
+
+        val state = player.world.getBlockState(pos)
+
+        //Check if block is still there
+        if(state.isAir
+          || state.block is FluidBlock
+          || state.block === Blocks.BEDROCK
+          || state.getHardness(player.world, pos) <= -1)
+        {
+          stopDigging(player)
+          continue
+        }
+
+        //Check if player is still looking at the block
+        val hit = PlayerHelpers.raycast(player)
+        if(hit.type != HitResult.Type.BLOCK || (hit as BlockHitResult).blockPos != pos){
+          stopDigging(player)
+          continue
+        }
+
+        val interactionManager = player.interactionManager as ServerPlayerInteractionManagerAccessor
+        val tickStartedMining = interactionManager.startMiningTime
+        val currentTick = interactionManager.tickCounter
+
+        if((currentTick - tickStartedMining) % 10 == 0){
+          player.swingHand(Hand.MAIN_HAND, true)
+        }
+
+        val progress = (interactionManager as ServerPlayerInteractionManagerInvoker).invokeContinueMining(player.world.getBlockState(pos), pos, tickStartedMining)
+
+        //Call custom setBlockBreakingInfo so block update is actually sent to triggering player
+        setBlockBreakingInfo(server, player.world, player.id, pos, (progress * 10).toInt())
+
+        if(progress >= 1){
+          player.interactionManager.tryBreakBlock(pos)
+          trackedDigEvents.remove(player)
+        }
+      }
+    })
   }
 }

--- a/src/main/java/io/sc3/plethora/integration/vanilla/method/EntityKineticMethods.kt
+++ b/src/main/java/io/sc3/plethora/integration/vanilla/method/EntityKineticMethods.kt
@@ -136,6 +136,23 @@ object EntityKineticMethods {
     return FutureMethodResult.result(trackedDigEvents.containsKey(player))
   }
 
+  val STOP_SWINGING = SubtargetedModuleMethod.of(
+    "stopSwinging", KINETIC_M, LivingEntity::class.java,
+    "function():boolean -- Stops the player from swinging their main hand."
+  ) { unbaked, _ -> stopSwinging(unbaked) }
+  private fun stopSwinging(unbaked: IUnbakedContext<IModuleContainer>): FutureMethodResult {
+    val ctx = KineticMethods.getContext(unbaked)
+    val playerCtx = KineticMethods.getPlayer(ctx)
+    val player = playerCtx.player
+
+    if(!trackedDigEvents.containsKey(player)){
+      return FutureMethodResult.result(false)
+    }
+
+    stopDigging(player)
+    return FutureMethodResult.result(true)
+  }
+
   private fun startDigging(player: ServerPlayerEntity, baseHit: BlockHitResult) {
     if(trackedDigEvents.containsKey(player)){
       stopDigging(player)

--- a/src/main/java/io/sc3/plethora/integration/vanilla/method/EntityKineticMethods.kt
+++ b/src/main/java/io/sc3/plethora/integration/vanilla/method/EntityKineticMethods.kt
@@ -22,6 +22,7 @@ import net.minecraft.network.packet.c2s.play.PlayerActionC2SPacket
 import net.minecraft.network.packet.s2c.play.BlockBreakingProgressS2CPacket
 import net.minecraft.network.packet.s2c.play.PositionFlag
 import net.minecraft.server.MinecraftServer
+import net.minecraft.server.network.ServerPlayNetworkHandler
 import net.minecraft.server.network.ServerPlayerEntity
 import net.minecraft.text.Text
 import net.minecraft.util.Hand
@@ -30,6 +31,7 @@ import net.minecraft.util.hit.EntityHitResult
 import net.minecraft.util.hit.HitResult
 import net.minecraft.util.math.BlockPos
 import net.minecraft.util.math.MathHelper
+import net.minecraft.util.math.Vec3d
 import net.minecraft.world.World
 import java.util.*
 
@@ -181,6 +183,11 @@ object EntityKineticMethods {
 
         if(player.isDisconnected){
           trackedDigEvents.remove(player)
+          continue
+        }
+
+        if(player.getEyePos().squaredDistanceTo(Vec3d.ofCenter(pos)) > ServerPlayNetworkHandler.MAX_BREAK_SQUARED_DISTANCE){
+          stopDigging(player)
           continue
         }
 

--- a/src/main/java/io/sc3/plethora/integration/vanilla/method/EntityKineticMethods.kt
+++ b/src/main/java/io/sc3/plethora/integration/vanilla/method/EntityKineticMethods.kt
@@ -111,7 +111,12 @@ object EntityKineticMethods {
             FutureMethodResult.result(result.left, result.right)
           } else {
             startDigging(player, hit)
-            FutureMethodResult.result(true, "Block")
+
+            if(player.world.canPlayerModifyAt(player, baseHit.blockPos)){
+              FutureMethodResult.result(true, "Block")
+            }else {
+              FutureMethodResult.result(false, "No permission to break here")
+            }
           }
         }
         else -> {

--- a/src/main/java/io/sc3/plethora/integration/vanilla/registry/VanillaMethodRegistration.kt
+++ b/src/main/java/io/sc3/plethora/integration/vanilla/registry/VanillaMethodRegistration.kt
@@ -17,7 +17,7 @@ object VanillaMethodRegistration {
       method("kinetic:look", EntityKineticMethods.LOOK)
       method("kinetic:use", EntityKineticMethods.USE)
       method("kinetic:swing", EntityKineticMethods.SWING)
-      method("kinetic:swinging", EntityKineticMethods.SWINGING)
+      method("kinetic:isSwinging", EntityKineticMethods.IS_SWINGING)
 
       method("introspection:consume", RangedInventoryWrapperMethods.CONSUME)
       method("introspection:drop", RangedInventoryWrapperMethods.DROP)

--- a/src/main/java/io/sc3/plethora/integration/vanilla/registry/VanillaMethodRegistration.kt
+++ b/src/main/java/io/sc3/plethora/integration/vanilla/registry/VanillaMethodRegistration.kt
@@ -18,6 +18,7 @@ object VanillaMethodRegistration {
       method("kinetic:use", EntityKineticMethods.USE)
       method("kinetic:swing", EntityKineticMethods.SWING)
       method("kinetic:isSwinging", EntityKineticMethods.IS_SWINGING)
+      method("kinetic:stopSwinging", EntityKineticMethods.STOP_SWINGING)
 
       method("introspection:consume", RangedInventoryWrapperMethods.CONSUME)
       method("introspection:drop", RangedInventoryWrapperMethods.DROP)

--- a/src/main/java/io/sc3/plethora/integration/vanilla/registry/VanillaMethodRegistration.kt
+++ b/src/main/java/io/sc3/plethora/integration/vanilla/registry/VanillaMethodRegistration.kt
@@ -17,6 +17,7 @@ object VanillaMethodRegistration {
       method("kinetic:look", EntityKineticMethods.LOOK)
       method("kinetic:use", EntityKineticMethods.USE)
       method("kinetic:swing", EntityKineticMethods.SWING)
+      method("kinetic:swinging", EntityKineticMethods.SWINGING)
 
       method("introspection:consume", RangedInventoryWrapperMethods.CONSUME)
       method("introspection:drop", RangedInventoryWrapperMethods.DROP)

--- a/src/main/java/io/sc3/plethora/mixin/ServerPlayerInteractionManagerAccessor.java
+++ b/src/main/java/io/sc3/plethora/mixin/ServerPlayerInteractionManagerAccessor.java
@@ -11,6 +11,13 @@ public interface ServerPlayerInteractionManagerAccessor {
 
     @Accessor
     int getBlockBreakingProgress();
+
     @Accessor
     void setBlockBreakingProgress(int progress);
+
+    @Accessor
+    int getStartMiningTime();
+
+    @Accessor
+    int getTickCounter();
 }

--- a/src/main/java/io/sc3/plethora/mixin/ServerPlayerInteractionManagerInvoker.java
+++ b/src/main/java/io/sc3/plethora/mixin/ServerPlayerInteractionManagerInvoker.java
@@ -1,0 +1,13 @@
+package io.sc3.plethora.mixin;
+
+import net.minecraft.block.BlockState;
+import net.minecraft.server.network.ServerPlayerInteractionManager;
+import net.minecraft.util.math.BlockPos;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Invoker;
+
+@Mixin(ServerPlayerInteractionManager.class)
+public interface ServerPlayerInteractionManagerInvoker {
+  @Invoker
+  float invokeContinueMining(BlockState state, BlockPos pos, int failedStartMiningTime);
+}

--- a/src/main/resources/plethora.mixins.json
+++ b/src/main/resources/plethora.mixins.json
@@ -10,6 +10,7 @@
     "LivingEntityMixin",
     "MeleeAttackGoalMixin",
     "ServerPlayerInteractionManagerAccessor",
+    "ServerPlayerInteractionManagerInvoker",
     "ServerPlayNetworkHandlerAdapter",
     "ServerWorldMixin",
     "SimpleInventoryAccessor",


### PR DESCRIPTION
Fix issue with Kinetic swing not working for breaking blocks

Add 2 new methods
- IsSwinging
  - Will return whether or not the player is swinging as a result of calling "Swing".  This will only be true if the player is swinging at a block.
- StopSwinging
  - Allows the player to stop swinging.